### PR TITLE
fix(firma): Añadir validación de equipo_id en JS para guardar/borrar …

### DIFF
--- a/rdm/equipos/imprimir_ficha.php
+++ b/rdm/equipos/imprimir_ficha.php
@@ -190,6 +190,10 @@ $assets_path_prefix = '../assets';
 
         if (guardarBtn && signaturePadContainer) { // Verificar signaturePadContainer para equipoId
             guardarBtn.addEventListener('click', function () {
+                if (!equipoId || parseInt(equipoId, 10) <= 0) {
+                    alert('Error: No se pudo obtener el ID del equipo para guardar la firma. Recargue la página.');
+                    return;
+                }
                 if (!signaturePad || signaturePad.isEmpty()) {
                     alert("Por favor, provea una firma primero.");
                 } else {
@@ -223,6 +227,10 @@ $assets_path_prefix = '../assets';
 
         if (borrarBtn && signaturePadContainer) {
              borrarBtn.addEventListener('click', function () {
+                if (!equipoId || parseInt(equipoId, 10) <= 0) {
+                    alert('Error: No se pudo obtener el ID del equipo para borrar la firma. Recargue la página.');
+                    return;
+                }
                 if (!confirm("¿Está seguro de que desea borrar la firma existente?")) return;
                 fetch('borrar_firma.php', {
                     method: 'POST',


### PR DESCRIPTION
…firma

He añadido una validación en el JavaScript de `equipos/imprimir_ficha.php` para asegurar que `equipoId` sea un valor numérico válido antes de intentar enviar la solicitud AJAX a `guardar_firma.php` o `borrar_firma.php`.

Esto ayuda a diagnosticar si el problema de "ID de equipo no válido" se origina en el lado del cliente (al no poder obtener el ID correctamente del DOM) o si el ID se envía pero se interpreta incorrectamente en el servidor.

Si la alerta del lado del cliente aparece, el problema está en la obtención del ID del DOM. Si la alerta no aparece pero el error del servidor persiste, se necesitará más depuración en el backend.