### PR TITLE
fix(nav): Ajustes en JS de menú y enlace 'Mi Perfil'

### DIFF
--- a/rdm/assets/js/main.js
+++ b/rdm/assets/js/main.js
@@ -19,9 +19,7 @@ document.addEventListener('DOMContentLoaded', function () {
             if (toggle.getAttribute('href') === '#') {
                 event.preventDefault();
             }
-            // Stop propagation to prevent the document click listener from immediately closing it
-            // if it was meant to open.
-            event.stopPropagation();
+            // event.stopPropagation(); // Moved to the end of this event listener
 
             var parentLi = toggle.closest('.nav-item.dropdown');
             if (!parentLi) return;
@@ -44,8 +42,13 @@ document.addEventListener('DOMContentLoaded', function () {
             }
 
             // Toggle current dropdown
+            console.log('Toggling menu for:', toggle.id || toggle.textContent.trim()); // Debugging line
             var isShown = an_Menu.classList.toggle('show');
             toggle.setAttribute('aria-expanded', isShown.toString());
+
+            // Stop propagation to prevent the document click listener from immediately closing it
+            // if it was meant to open, and to prevent other handlers if necessary.
+            event.stopPropagation();
         });
     });
 

--- a/rdm/includes/header.php
+++ b/rdm/includes/header.php
@@ -112,7 +112,7 @@ $global_search_action_path = $nav_base_path . "/global_search_results.php";
                             <i class="bi bi-person-circle"></i> <?php echo htmlspecialchars($_SESSION['nombre_usuario']); ?> (<?php echo htmlspecialchars($_SESSION['rol']); ?>)
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarUserDropdown">
-                            <li><a class="dropdown-item" href="#">Mi Perfil</a></li> <!-- Placeholder -->
+                            <li><a class="dropdown-item" href="<?php echo $nav_base_path; ?>/dashboard.php">Mi Perfil (Ver Dashboard)</a></li>
                             <li><hr class="dropdown-divider"></li>
                             <li><a class="dropdown-item" href="<?php echo $nav_base_path; ?>/logout.php">Cerrar Sesión</a></li>
                         </ul>


### PR DESCRIPTION
Se realizaron los siguientes cambios:
1. En `rdm/assets/js/main.js`:
    - Se movió `event.stopPropagation()` al final del manejador de clics de los toggles de menú, para potencialmente mejorar la interacción de eventos.
    - Se añadió un `console.log` para facilitar la depuración de qué menús están siendo procesados por el script personalizado.
2. En `rdm/includes/header.php`:
    - El enlace 'Mi Perfil' dentro del menú desplegable del usuario ahora apunta a `dashboard.php` como una acción placeholder.
    - El texto del enlace se actualizó a 'Mi Perfil (Ver Dashboard)'.

Estos cambios buscan mejorar la funcionalidad del menú desplegable del usuario en PC y proveer una acción funcional para el enlace 'Mi Perfil' en todas las vistas.