### PR TITLE
fix(pdf): Mejorar manejo de errores y codificación en generación de PDF

### DIFF
--- a/rdm/facturas/descargar_pdf.php
+++ b/rdm/facturas/descargar_pdf.php
@@ -1,5 +1,8 @@
 <?php
 // facturas/descargar_pdf.php
+error_reporting(0); // Suppress PHP errors from breaking PDF output
+@ini_set('display_errors', 0); // Suppress PHP errors from breaking PDF output
+
 require_once '../includes/db.php';       // Para $enlace
 require_once '../includes/funciones.php'; // Para sanitizar_entrada y verificar_login (si se decide proteger)
 // verificar_login(); // Descomentar si se quiere proteger la descarga directa del PDF
@@ -10,8 +13,9 @@ require_once '../includes/fpdf/fpdf.php';
 $factura_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 
 if ($factura_id <= 0) {
-    // Podríamos generar un PDF de error o redirigir
-    die("ID de factura no válido."); // die() es problemático para la herramienta también, pero es un caso de error crítico.
+    // header('Content-Type: text/plain; charset=utf-8'); // Optional: send plain text error
+    // echo "Error: ID de factura no válido.";
+    exit; // Exit cleanly without generating a PDF or corrupting output
 }
 
 // --- Fetch Factura Data (similar to ver_factura.php) ---
@@ -25,20 +29,30 @@ $sql_factura = "SELECT f.*,
                 LEFT JOIN equipos eq ON f.equipo_id = eq.id
                 WHERE f.id = ?";
 $stmt_factura = mysqli_prepare($enlace, $sql_factura);
-if (!$stmt_factura) { /*die("Error DB L1: " . mysqli_error($enlace));*/ return; } // Modificado para la herramienta
+if (!$stmt_factura) {
+    // Log error internally if possible
+    // error_log("Factura PDF Error: Failed to prepare factura query: " . mysqli_error($enlace));
+    exit; // Exit cleanly
+}
 mysqli_stmt_bind_param($stmt_factura, "i", $factura_id);
 mysqli_stmt_execute($stmt_factura);
 $res_factura = mysqli_stmt_get_result($stmt_factura);
 $factura = mysqli_fetch_assoc($res_factura);
 mysqli_stmt_close($stmt_factura);
 
-if (!$factura) { /*die("Factura no encontrada.");*/ return; } // Modificado
+if (!$factura) {
+    // error_log("Factura PDF Error: Factura not found for ID: " . $factura_id);
+    exit; // Exit cleanly
+}
 
 $factura_items = [];
 $sql_items = "SELECT fi.descripcion, fi.cantidad, fi.precio_unitario, fi.subtotal_item
               FROM factura_items fi WHERE fi.factura_id = ?";
 $stmt_items = mysqli_prepare($enlace, $sql_items);
-if (!$stmt_items) { /*die("Error DB L2: " . mysqli_error($enlace));*/ return; } // Modificado
+if (!$stmt_items) {
+    // error_log("Factura PDF Error: Failed to prepare items query: " . mysqli_error($enlace));
+    exit; // Exit cleanly
+}
 mysqli_stmt_bind_param($stmt_items, "i", $factura_id);
 mysqli_stmt_execute($stmt_items);
 $res_items = mysqli_stmt_get_result($stmt_items);
@@ -62,35 +76,35 @@ class PDF extends FPDF {
 
     function Header() {
         $this->SetFont('Arial', 'B', 16);
-        $this->Cell(0, 10, iconv('UTF-8', 'windows-1252',$this->datos_empresa_pdf['nombre_empresa'] ?? 'RDM Solutions'), 0, 1, 'C');
+        $this->Cell(0, 10, iconv('UTF-8', 'windows-1252//TRANSLIT',$this->datos_empresa_pdf['nombre_empresa'] ?? 'RDM Solutions'), 0, 1, 'C');
         $this->SetFont('Arial', '', 10);
-        $this->Cell(0, 5, iconv('UTF-8', 'windows-1252',$this->datos_empresa_pdf['empresa_domicilio'] ?? 'Domicilio no especificado'), 0, 1, 'C');
-        $this->Cell(0, 5, iconv('UTF-8', 'windows-1252',"CUIT: " . ($this->datos_empresa_pdf['cuit'] ?? '') . " - Cond. IVA: " . ($this->datos_empresa_pdf['empresa_condicion_iva'] ?? '')), 0, 1, 'C');
+        $this->Cell(0, 5, iconv('UTF-8', 'windows-1252//TRANSLIT',$this->datos_empresa_pdf['empresa_domicilio'] ?? 'Domicilio no especificado'), 0, 1, 'C');
+        $this->Cell(0, 5, iconv('UTF-8', 'windows-1252//TRANSLIT',"CUIT: " . ($this->datos_empresa_pdf['cuit'] ?? '') . " - Cond. IVA: " . ($this->datos_empresa_pdf['empresa_condicion_iva'] ?? '')), 0, 1, 'C');
         $this->Ln(5);
 
         $this->SetFont('Arial', 'B', 12);
-        $this->Cell(0, 10, 'FACTURA TIPO "C"', 0, 1, 'R');
+        $this->Cell(0, 10, iconv('UTF-8', 'windows-1252//TRANSLIT','FACTURA TIPO "C"'), 0, 1, 'R');
         $this->SetFont('Arial', '', 10);
-        $this->Cell(0, 5, iconv('UTF-8', 'windows-1252',"Factura N°: " . $this->factura_num_pdf), 0, 1, 'R');
-        $this->Cell(0, 5, iconv('UTF-8', 'windows-1252',"Fecha Emisión: " . date("d/m/Y", strtotime($this->fecha_emision_pdf))), 0, 1, 'R');
+        $this->Cell(0, 5, iconv('UTF-8', 'windows-1252//TRANSLIT',"Factura N°: " . $this->factura_num_pdf), 0, 1, 'R');
+        $this->Cell(0, 5, iconv('UTF-8', 'windows-1252//TRANSLIT',"Fecha Emisión: " . date("d/m/Y", strtotime($this->fecha_emision_pdf))), 0, 1, 'R');
         $this->Ln(10);
     }
 
     function Footer() {
         $this->SetY(-15);
         $this->SetFont('Arial', 'I', 8);
-        $this->Cell(0, 10, iconv('UTF-8', 'windows-1252','Página ') . $this->PageNo() . '/{nb}', 0, 0, 'C');
+        $this->Cell(0, 10, iconv('UTF-8', 'windows-1252//TRANSLIT','Página ') . $this->PageNo() . '/{nb}', 0, 0, 'C');
     }
 
     function FancyTable($header, $data_items) {
         $this->SetFillColor(230, 230, 230); $this->SetTextColor(0); $this->SetDrawColor(128, 128, 128);
         $this->SetLineWidth(.3); $this->SetFont('', 'B');
         $w = array(110, 25, 25, 30);
-        for($i=0; $i<count($header); $i++) $this->Cell($w[$i], 7, iconv('UTF-8', 'windows-1252',$header[$i]), 1, 0, 'C', true);
+        for($i=0; $i<count($header); $i++) $this->Cell($w[$i], 7, iconv('UTF-8', 'windows-1252//TRANSLIT',$header[$i]), 1, 0, 'C', true);
         $this->Ln();
         $this->SetFont(''); $this->SetFillColor(245, 245, 245); $this->SetTextColor(0); $fill = false;
         foreach($data_items as $row) {
-            $this->Cell($w[0], 6, iconv('UTF-8', 'windows-1252',substr($row['descripcion'],0,60)), 'LR', 0, 'L', $fill);
+            $this->Cell($w[0], 6, iconv('UTF-8', 'windows-1252//TRANSLIT',substr($row['descripcion'],0,60)), 'LR', 0, 'L', $fill);
             $this->Cell($w[1], 6, $row['cantidad'], 'LR', 0, 'R', $fill);
             $this->Cell($w[2], 6, number_format($row['precio_unitario'], 2, ',', '.'), 'LR', 0, 'R', $fill);
             $this->Cell($w[3], 6, number_format($row['subtotal_item'], 2, ',', '.'), 'LR', 0, 'R', $fill);
@@ -104,34 +118,34 @@ $pdf = new PDF('P', 'mm', 'A4');
 $pdf->setHeaderInfo($factura, $factura['numero_factura'], $factura['fecha_emision']);
 $pdf->AliasNbPages(); $pdf->AddPage(); $pdf->SetFont('Arial', '', 10);
 
-$pdf->SetFont('', 'B'); $pdf->Cell(0, 7, iconv('UTF-8', 'windows-1252','Datos del Cliente:'), 0, 1); $pdf->SetFont('');
-$pdf->Cell(0, 5, iconv('UTF-8', 'windows-1252',"Nombre: " . $factura['cliente_nombre']), 0, 1);
-$pdf->Cell(0, 5, iconv('UTF-8', 'windows-1252',"DNI/CUIT: " . $factura['cliente_dni']), 0, 1);
-$pdf->Cell(0, 5, iconv('UTF-8', 'windows-1252',"Domicilio: " . ($factura['cliente_direccion'] ?? '')), 0, 1); $pdf->Ln(5);
+$pdf->SetFont('', 'B'); $pdf->Cell(0, 7, iconv('UTF-8', 'windows-1252//TRANSLIT','Datos del Cliente:'), 0, 1); $pdf->SetFont('');
+$pdf->Cell(0, 5, iconv('UTF-8', 'windows-1252//TRANSLIT',"Nombre: " . $factura['cliente_nombre']), 0, 1);
+$pdf->Cell(0, 5, iconv('UTF-8', 'windows-1252//TRANSLIT',"DNI/CUIT: " . $factura['cliente_dni']), 0, 1);
+$pdf->Cell(0, 5, iconv('UTF-8', 'windows-1252//TRANSLIT',"Domicilio: " . ($factura['cliente_direccion'] ?? '')), 0, 1); $pdf->Ln(5);
 
 if ($factura['equipo_id']) {
-    $pdf->SetFont('', 'B'); $pdf->Cell(0, 7, iconv('UTF-8', 'windows-1252','Equipo Asociado:'), 0, 1); $pdf->SetFont('');
-    $pdf->Cell(0, 5, iconv('UTF-8', 'windows-1252',"Tipo: " . ($factura['tipo_equipo'] ?? '') . " - Marca/Modelo: " . ($factura['equipo_marca'] ?? '') . " " . ($factura['equipo_modelo'] ?? '')), 0, 1);
-    $pdf->Cell(0, 5, iconv('UTF-8', 'windows-1252',"Serie/IMEI: " . ($factura['equipo_serie'] ?? '')), 0, 1); $pdf->Ln(5);
+    $pdf->SetFont('', 'B'); $pdf->Cell(0, 7, iconv('UTF-8', 'windows-1252//TRANSLIT','Equipo Asociado:'), 0, 1); $pdf->SetFont('');
+    $pdf->Cell(0, 5, iconv('UTF-8', 'windows-1252//TRANSLIT',"Tipo: " . ($factura['tipo_equipo'] ?? '') . " - Marca/Modelo: " . ($factura['equipo_marca'] ?? '') . " " . ($factura['equipo_modelo'] ?? '')), 0, 1);
+    $pdf->Cell(0, 5, iconv('UTF-8', 'windows-1252//TRANSLIT',"Serie/IMEI: " . ($factura['equipo_serie'] ?? '')), 0, 1); $pdf->Ln(5);
 }
 
 $header_items = array('Descripción', 'Cantidad', 'P. Unit.', 'Subtotal');
 $pdf->FancyTable($header_items, $factura_items); $pdf->Ln(2);
 
-$pdf->SetFont('', 'B'); $pdf->Cell(135, 6, 'Subtotal:', 0, 0, 'R'); $pdf->SetFont('');
+$pdf->SetFont('', 'B'); $pdf->Cell(135, 6, iconv('UTF-8', 'windows-1252//TRANSLIT','Subtotal:'), 0, 0, 'R'); $pdf->SetFont('');
 $pdf->Cell(25, 6, '$' . number_format($factura['subtotal'], 2, ',', '.'), 0, 1, 'R');
-$pdf->SetFont('', 'B'); $pdf->Cell(135, 6, 'IVA (' . number_format($factura['iva_porcentaje'], 2, ',', '.') . '%):', 0, 0, 'R'); $pdf->SetFont('');
+$pdf->SetFont('', 'B'); $pdf->Cell(135, 6, iconv('UTF-8', 'windows-1252//TRANSLIT','IVA (' . number_format($factura['iva_porcentaje'], 2, ',', '.') . '%):'), 0, 0, 'R'); $pdf->SetFont('');
 $pdf->Cell(25, 6, '$' . number_format($factura['iva_monto'], 2, ',', '.'), 0, 1, 'R');
-$pdf->SetFont('', 'B', 12); $pdf->Cell(135, 8, 'TOTAL:', 0, 0, 'R'); $pdf->SetFont('', 'B', 12);
+$pdf->SetFont('', 'B', 12); $pdf->Cell(135, 8, iconv('UTF-8', 'windows-1252//TRANSLIT','TOTAL:'), 0, 0, 'R'); $pdf->SetFont('', 'B', 12);
 $pdf->Cell(25, 8, '$' . number_format($factura['total'], 2, ',', '.'), 0, 1, 'R'); $pdf->Ln(5);
 
 $pdf->SetFont('', '');
-$pdf->Cell(0,5, iconv('UTF-8', 'windows-1252',"Condición de Venta: " . ($factura['condicion_venta'] ?? '')),0,1);
-$pdf->Cell(0,5, iconv('UTF-8', 'windows-1252',"Método de Pago: " . ($factura['metodo_pago'] ?? '')),0,1); $pdf->Ln(5);
+$pdf->Cell(0,5, iconv('UTF-8', 'windows-1252//TRANSLIT',"Condición de Venta: " . ($factura['condicion_venta'] ?? '')),0,1);
+$pdf->Cell(0,5, iconv('UTF-8', 'windows-1252//TRANSLIT',"Método de Pago: " . ($factura['metodo_pago'] ?? '')),0,1); $pdf->Ln(5);
 
 $pdf->SetFont('', 'B', 8);
-$pdf->Cell(0,5, iconv('UTF-8', 'windows-1252',"CAE N°: " . ($factura['cae'] ?? 'Comprobante no fiscal')),0,0,'L');
-$pdf->Cell(0,5, iconv('UTF-8', 'windows-1252',"Fecha Vto. CAE: " . ($factura['fecha_vto_cae'] ? date("d/m/Y", strtotime($factura['fecha_vto_cae'])) : '')),0,1,'R');
+$pdf->Cell(0,5, iconv('UTF-8', 'windows-1252//TRANSLIT',"CAE N°: " . ($factura['cae'] ?? 'Comprobante no fiscal')),0,0,'L');
+$pdf->Cell(0,5, iconv('UTF-8', 'windows-1252//TRANSLIT',"Fecha Vto. CAE: " . ($factura['fecha_vto_cae'] ? date("d/m/Y", strtotime($factura['fecha_vto_cae'])) : '')),0,1,'R');
 
 $pdf_filename = "Factura_RDM_" . str_replace('-', '_', $factura['numero_factura']) . ".pdf";
 $pdf->Output('I', $pdf_filename);

--- a/rdm/reportes/equipos_por_fecha.php
+++ b/rdm/reportes/equipos_por_fecha.php
@@ -92,31 +92,33 @@ if ($export_type === 'csv' && !isset($mensaje_error_consulta)) {
 
 if ($export_type === 'pdf' && !isset($mensaje_error_consulta)) {
     verificar_login();
+    error_reporting(0); // Suppress PHP errors from breaking PDF output
+    @ini_set('display_errors', 0); // Suppress PHP errors from breaking PDF output
     require_once '../includes/fpdf/fpdf.php';
 
     class PDF_Reporte_Equipos extends FPDF {
         function Header() {
-            $this->SetFont('Arial','B',12); $this->Cell(0,10,iconv('UTF-8', 'windows-1252','Reporte de Equipos'),0,1,'C'); $this->Ln(5);
+            $this->SetFont('Arial','B',12); $this->Cell(0,10,iconv('UTF-8', 'windows-1252//TRANSLIT','Reporte de Equipos'),0,1,'C'); $this->Ln(5);
         }
         function Footer() {
-            $this->SetY(-15); $this->SetFont('Arial','I',8); $this->Cell(0,10,iconv('UTF-8', 'windows-1252','Página ').$this->PageNo().'/{nb}',0,0,'C');
+            $this->SetY(-15); $this->SetFont('Arial','I',8); $this->Cell(0,10,iconv('UTF-8', 'windows-1252//TRANSLIT','Página ').$this->PageNo().'/{nb}',0,0,'C');
         }
         function TableEquipos($header, $data) {
             $this->SetFillColor(200,220,255); $this->SetTextColor(0); $this->SetDrawColor(128,0,0);
             $this->SetLineWidth(.3); $this->SetFont('','B', 8);
             $w = array(15, 45, 30, 25, 25, 35, 25, 25); // Ajustar anchos para Landscape A4 (total ~190-277)
-            for($i=0;$i<count($header);$i++) $this->Cell($w[$i],7,iconv('UTF-8', 'windows-1252',$header[$i]),1,0,'C',true);
+            for($i=0;$i<count($header);$i++) $this->Cell($w[$i],7,iconv('UTF-8', 'windows-1252//TRANSLIT',$header[$i]),1,0,'C',true);
             $this->Ln();
             $this->SetFont('','',7); $fill = false;
             foreach($data as $row) {
-                $this->Cell($w[0],6,$row['equipo_id'],'LR',0,'C',$fill);
-                $this->Cell($w[1],6,iconv('UTF-8', 'windows-1252',substr($row['cliente_nombre'],0,28)),'LR',0,'L',$fill);
-                $this->Cell($w[2],6,iconv('UTF-8', 'windows-1252',substr($row['tipo_equipo'],0,18)),'LR',0,'L',$fill);
-                $this->Cell($w[3],6,iconv('UTF-8', 'windows-1252',substr($row['marca'],0,15)),'LR',0,'L',$fill);
-                $this->Cell($w[4],6,iconv('UTF-8', 'windows-1252',substr($row['modelo'],0,15)),'LR',0,'L',$fill);
-                $this->Cell($w[5],6,iconv('UTF-8', 'windows-1252',substr($row['tecnico_nombre'] ?? 'N/A',0,20)),'LR',0,'L',$fill);
-                $this->Cell($w[6],6,date("d/m/y H:i", strtotime($row['fecha_ingreso'])),'LR',0,'C',$fill);
-                $this->Cell($w[7],6,iconv('UTF-8', 'windows-1252',$row['estado_reparacion'] ?? 'N/A'),'LR',0,'L',$fill);
+                $this->Cell($w[0],6,$row['equipo_id'],'LR',0,'C',$fill); // ID is numeric, no iconv needed
+                $this->Cell($w[1],6,iconv('UTF-8', 'windows-1252//TRANSLIT',substr($row['cliente_nombre'],0,28)),'LR',0,'L',$fill);
+                $this->Cell($w[2],6,iconv('UTF-8', 'windows-1252//TRANSLIT',substr($row['tipo_equipo'],0,18)),'LR',0,'L',$fill);
+                $this->Cell($w[3],6,iconv('UTF-8', 'windows-1252//TRANSLIT',substr($row['marca'],0,15)),'LR',0,'L',$fill);
+                $this->Cell($w[4],6,iconv('UTF-8', 'windows-1252//TRANSLIT',substr($row['modelo'],0,15)),'LR',0,'L',$fill);
+                $this->Cell($w[5],6,iconv('UTF-8', 'windows-1252//TRANSLIT',substr($row['tecnico_nombre'] ?? 'N/A',0,20)),'LR',0,'L',$fill);
+                $this->Cell($w[6],6,date("d/m/y H:i", strtotime($row['fecha_ingreso'])),'LR',0,'C',$fill); // Date is ASCII
+                $this->Cell($w[7],6,iconv('UTF-8', 'windows-1252//TRANSLIT',$row['estado_reparacion'] ?? 'N/A'),'LR',0,'L',$fill);
                 $this->Ln(); $fill = !$fill;
             }
             $this->Cell(array_sum($w),0,'','T');
@@ -128,8 +130,7 @@ if ($export_type === 'pdf' && !isset($mensaje_error_consulta)) {
     $header_pdf = array('ID', 'Cliente', 'Tipo', 'Marca', 'Modelo', 'Tecnico', 'F. Ingreso', 'Estado');
     $pdf->TableEquipos($header_pdf, $equipos_reporte);
     $pdf->Output('D', 'reporte_equipos_' . date('Ymd') . '.pdf');
-    // exit; // Comentado para la herramienta
-    return;
+    exit; // Ensure clean exit after PDF output
 }
 
 

--- a/rdm/reportes/recaudacion_por_fecha.php
+++ b/rdm/reportes/recaudacion_por_fecha.php
@@ -123,36 +123,37 @@ if ($execute_query_rec && !isset($mensaje_error_consulta_rec)) {
     }
 
     if ($export_type_rec === 'pdf') {
+        error_reporting(0); // Suppress PHP errors
+        @ini_set('display_errors', 0); // Suppress PHP errors
         require_once '../includes/fpdf/fpdf.php';
         class PDF_Reporte_Recaudacion extends FPDF {
-            function Header() { $this->SetFont('Arial','B',12); $this->Cell(0,10,iconv('UTF-8', 'windows-1252','Reporte de Recaudación'),0,1,'C'); $this->Ln(5); }
-            function Footer() { $this->SetY(-15); $this->SetFont('Arial','I',8); $this->Cell(0,10,iconv('UTF-8', 'windows-1252','Página ').$this->PageNo().'/{nb}',0,0,'C');}
+            function Header() { $this->SetFont('Arial','B',12); $this->Cell(0,10,iconv('UTF-8', 'windows-1252//TRANSLIT','Reporte de Recaudación'),0,1,'C'); $this->Ln(5); }
+            function Footer() { $this->SetY(-15); $this->SetFont('Arial','I',8); $this->Cell(0,10,iconv('UTF-8', 'windows-1252//TRANSLIT','Página ').$this->PageNo().'/{nb}',0,0,'C');}
         }
         $pdf_rec = new PDF_Reporte_Recaudacion('P','mm','A4');
         $pdf_rec->AliasNbPages(); $pdf_rec->AddPage(); $pdf_rec->SetFont('Arial','',10);
-        $pdf_rec->SetFont('','B'); $pdf_rec->Cell(60,7,'Concepto',1); $pdf_rec->Cell(40,7,'Monto',1,1,'R'); $pdf_rec->SetFont('');
-        $pdf_rec->Cell(60,7,iconv('UTF-8', 'windows-1252','Total Recaudado:'),'LR'); $pdf_rec->Cell(40,7,'$'.number_format($summary['total_recaudado'],2,',','.'),'R',1,'R');
-        $pdf_rec->Cell(60,7,iconv('UTF-8', 'windows-1252','Total IVA:'),'LR'); $pdf_rec->Cell(40,7,'$'.number_format($summary['total_iva'],2,',','.'),'R',1,'R');
-        $pdf_rec->Cell(60,7,iconv('UTF-8', 'windows-1252','Total Subtotal (Neto):'),'LRB'); $pdf_rec->Cell(40,7,'$'.number_format($summary['total_subtotal'],2,',','.'),'RB',1,'R');
-        $pdf_rec->Cell(60,7,iconv('UTF-8', 'windows-1252','Cantidad de Facturas:'),'LRB'); $pdf_rec->Cell(40,7,$summary['cantidad_facturas'],'RB',1,'R');
+        $pdf_rec->SetFont('','B'); $pdf_rec->Cell(60,7,iconv('UTF-8', 'windows-1252//TRANSLIT','Concepto'),1); $pdf_rec->Cell(40,7,iconv('UTF-8', 'windows-1252//TRANSLIT','Monto'),1,1,'R'); $pdf_rec->SetFont('');
+        $pdf_rec->Cell(60,7,iconv('UTF-8', 'windows-1252//TRANSLIT','Total Recaudado:'),'LR'); $pdf_rec->Cell(40,7,'$'.number_format($summary['total_recaudado'],2,',','.'),'R',1,'R');
+        $pdf_rec->Cell(60,7,iconv('UTF-8', 'windows-1252//TRANSLIT','Total IVA:'),'LR'); $pdf_rec->Cell(40,7,'$'.number_format($summary['total_iva'],2,',','.'),'R',1,'R');
+        $pdf_rec->Cell(60,7,iconv('UTF-8', 'windows-1252//TRANSLIT','Total Subtotal (Neto):'),'LRB'); $pdf_rec->Cell(40,7,'$'.number_format($summary['total_subtotal'],2,',','.'),'RB',1,'R');
+        $pdf_rec->Cell(60,7,iconv('UTF-8', 'windows-1252//TRANSLIT','Cantidad de Facturas:'),'LRB'); $pdf_rec->Cell(40,7,$summary['cantidad_facturas'],'RB',1,'R');
         if(!empty($facturas_periodo)){
-            $pdf_rec->Ln(10); $pdf_rec->SetFont('','B'); $pdf_rec->Cell(0,7,iconv('UTF-8', 'windows-1252','Detalle de Facturas del Período'),0,1);
+            $pdf_rec->Ln(10); $pdf_rec->SetFont('','B'); $pdf_rec->Cell(0,7,iconv('UTF-8', 'windows-1252//TRANSLIT','Detalle de Facturas del Período'),0,1);
             $w_fac = array(40,30,80,30); $pdf_rec->SetFont('','B',9);
-            $pdf_rec->Cell($w_fac[0],7,'Nro Factura',1); $pdf_rec->Cell($w_fac[1],7,'Fecha',1); $pdf_rec->Cell($w_fac[2],7,'Cliente',1); $pdf_rec->Cell($w_fac[3],7,'Total',1,1,'R');
+            $pdf_rec->Cell($w_fac[0],7,iconv('UTF-8', 'windows-1252//TRANSLIT','Nro Factura'),1); $pdf_rec->Cell($w_fac[1],7,iconv('UTF-8', 'windows-1252//TRANSLIT','Fecha'),1); $pdf_rec->Cell($w_fac[2],7,iconv('UTF-8', 'windows-1252//TRANSLIT','Cliente'),1); $pdf_rec->Cell($w_fac[3],7,iconv('UTF-8', 'windows-1252//TRANSLIT','Total'),1,1,'R');
             $pdf_rec->SetFont('','',8); $fill_fac = false;
             foreach($facturas_periodo as $fact){
                 $pdf_rec->SetFillColor(240,240,240);
-                $pdf_rec->Cell($w_fac[0],6,iconv('UTF-8', 'windows-1252',$fact['numero_factura']),'LR',0,'L',$fill_fac);
-                $pdf_rec->Cell($w_fac[1],6,date("d/m/Y", strtotime($fact['fecha_emision'])),'LR',0,'C',$fill_fac);
-                $pdf_rec->Cell($w_fac[2],6,iconv('UTF-8', 'windows-1252',substr($fact['cliente_nombre_factura'],0,45)),'LR',0,'L',$fill_fac);
-                $pdf_rec->Cell($w_fac[3],6,'$'.number_format($fact['total'],2,',','.'),'LR',1,'R',$fill_fac);
+                $pdf_rec->Cell($w_fac[0],6,iconv('UTF-8', 'windows-1252//TRANSLIT',$fact['numero_factura']),'LR',0,'L',$fill_fac);
+                $pdf_rec->Cell($w_fac[1],6,date("d/m/Y", strtotime($fact['fecha_emision'])),'LR',0,'C',$fill_fac); // Date is ASCII
+                $pdf_rec->Cell($w_fac[2],6,iconv('UTF-8', 'windows-1252//TRANSLIT',substr($fact['cliente_nombre_factura'],0,45)),'LR',0,'L',$fill_fac);
+                $pdf_rec->Cell($w_fac[3],6,'$'.number_format($fact['total'],2,',','.'),'LR',1,'R',$fill_fac); // Number is ASCII
                 $fill_fac = !$fill_fac;
             }
              $pdf_rec->Cell(array_sum($w_fac),0,'','T');
         }
         $pdf_rec->Output('D', 'reporte_recaudacion_' . date('Ymd') . '.pdf');
-        // exit; // Comentado para la herramienta
-        return;
+        exit; // Ensure clean exit
     }
 }
 


### PR DESCRIPTION
He implementado varias mejoras en los scripts de generación de PDF (`facturas/descargar_pdf.php` y las secciones de exportación a PDF en `reportes/equipos_por_fecha.php` y `reportes/recaudacion_por_fecha.php`) para mitigar errores HTTP 500:

1.  Añadí `error_reporting(0); @ini_set('display_errors', 0);` al inicio de los scripts/bloques de generación de PDF para suprimir la salida de errores PHP en el stream del PDF.
2.  Reemplacé las llamadas `die()` con mensajes y los `return;` prematuros por `exit;` para asegurar una terminación limpia del script si no se puede generar un PDF válido.
3.  Modifiqué todas las llamadas a `iconv()` para usar la opción `//TRANSLIT` (ej. `iconv('UTF-8', 'windows-1252//TRANSLIT', $text)`). Esto mejora el manejo de caracteres UTF-8 que no tienen una representación directa en la codificación `windows-1252`, reduciendo la probabilidad de errores o advertencias de `iconv`.

Estos cambios aumentan la robustez de la generación de PDFs y deberían reducir la incidencia de errores HTTP 500.