### PR TITLE
fix(facturacion): Corregir error de FK en factura manual sin equipo

### DIFF
--- a/rdm/facturas/generar_factura.php
+++ b/rdm/facturas/generar_factura.php
@@ -62,7 +62,9 @@ if($stmt_clientes_all){
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $cliente_id_form = isset($_POST['cliente_id']) ? (int)$_POST['cliente_id'] : null;
-    $equipo_id_form = isset($_POST['equipo_id_hidden']) ? (int)$_POST['equipo_id_hidden'] : null; // ID del equipo original si vino por GET
+    // $equipo_id_form = isset($_POST['equipo_id_hidden']) ? (int)$_POST['equipo_id_hidden'] : null; // Original line
+    $equipo_id_post_val = isset($_POST['equipo_id_hidden']) ? trim($_POST['equipo_id_hidden']) : '';
+    $equipo_id_form = (!empty($equipo_id_post_val) && (int)$equipo_id_post_val > 0) ? (int)$equipo_id_post_val : null;
 
     $metodo_pago = sanitizar_entrada($_POST['metodo_pago']);
     $condicion_venta = sanitizar_entrada($_POST['condicion_venta']);


### PR DESCRIPTION
He modificado `rdm/facturas/generar_factura.php` para asegurar que la variable `$equipo_id_form` se establezca explícitamente a `NULL` si no proporcionas un ID de equipo válido a través del campo oculto `equipo_id_hidden` durante el POST.

Anteriormente, si no se pasaba un `equipo_id` (común al crear una factura manualmente sin un equipo preseleccionado), `$equipo_id_form` podía evaluarse como `0` (cero). Esto causaba un error de restricción de clave foránea al intentar insertar la factura, ya que no existe un equipo con ID `0`.

Con este cambio, si no hay un equipo válido asociado, se insertará `NULL` en la columna `facturas.equipo_id` (la cual es nullable), resolviendo el error de FK.