### PR TITLE
Restaurar main.js para investigar problema de menús desplegables

### DIFF
--- a/rdm/assets/js/main.js
+++ b/rdm/assets/js/main.js
@@ -1,1 +1,81 @@
-// Intentionally left blank or for future custom JS.
+document.addEventListener('DOMContentLoaded', function () {
+    var dropdownToggles = document.querySelectorAll('.navbar .dropdown-toggle');
+
+    dropdownToggles.forEach(function (toggle) {
+        // Skip the main navbar toggler button for mobile view
+        if (toggle.classList.contains('navbar-toggler')) {
+            return;
+        }
+        // Also skip user profile dropdown usually handled well by Bootstrap
+        if (toggle.closest('ul.navbar-nav:not(.me-auto)')) {
+             // This targets dropdowns in the right-aligned section of navbar
+             // Check if it's the user dropdown by ID if a more specific selector is needed
+             // if (toggle.id === 'navbarUserDropdown') return; // No longer skipping based on ID
+        }
+
+
+        toggle.addEventListener('click', function (event) {
+            // Prevent default for href="#" to avoid jumping to top of page
+            if (toggle.getAttribute('href') === '#') {
+                event.preventDefault();
+            }
+            // event.stopPropagation(); // Moved to the end of this event listener
+
+            var parentLi = toggle.closest('.nav-item.dropdown');
+            if (!parentLi) return;
+
+            var an_Menu = parentLi.querySelector('.dropdown-menu');
+            if (!an_Menu) return;
+
+            // Close other open dropdowns in the same navbar section (me-auto or the right-aligned one)
+            // This helps mimic expected Bootstrap behavior where only one dropdown is open at a time.
+            var navSection = parentLi.closest('.navbar-nav');
+            if(navSection){
+                var openDropdownsInSameSection = navSection.querySelectorAll('.nav-item.dropdown .dropdown-menu.show');
+                openDropdownsInSameSection.forEach(function(openDropdown) {
+                    if (openDropdown !== an_Menu) {
+                        openDropdown.classList.remove('show');
+                        var otherToggle = openDropdown.closest('.nav-item.dropdown').querySelector('.dropdown-toggle');
+                        if(otherToggle) otherToggle.setAttribute('aria-expanded', 'false');
+                    }
+                });
+            }
+
+            // Toggle current dropdown
+            console.log('Toggling menu for:', toggle.id || toggle.textContent.trim()); // Debugging line
+            var isShown = an_Menu.classList.toggle('show');
+            toggle.setAttribute('aria-expanded', isShown.toString());
+
+            // Stop propagation to prevent the document click listener from immediately closing it
+            // if it was meant to open, and to prevent other handlers if necessary.
+            event.stopPropagation();
+        });
+    });
+
+    // Close dropdowns if clicking outside
+    document.addEventListener('click', function (event) {
+        var openDropdowns = document.querySelectorAll('.navbar .dropdown-menu.show');
+        var targetElement = event.target;
+
+        // If the click is on the navbar toggler itself, don't close dropdowns, BS handles it
+        if (targetElement.closest('.navbar-toggler')) {
+            return;
+        }
+
+        var isInsideADropdownToggleOrMenu = false;
+        // Check if the click originated from within any dropdown toggle or its menu
+        document.querySelectorAll('.navbar .nav-item.dropdown').forEach(function(dropdownNavItem){
+            if(dropdownNavItem.contains(targetElement)){
+                isInsideADropdownToggleOrMenu = true;
+            }
+        });
+
+        if (!isInsideADropdownToggleOrMenu) {
+            openDropdowns.forEach(function (openDropdown) {
+                openDropdown.classList.remove('show');
+                var toggle = openDropdown.closest('.nav-item.dropdown').querySelector('.dropdown-toggle');
+                if(toggle) toggle.setAttribute('aria-expanded', 'false');
+            });
+        }
+    });
+});


### PR DESCRIPTION
Se ha restaurado el contenido original de `rdm/assets/js/main.js` como parte del proceso de diagnóstico del mal funcionamiento de los menús desplegables del navbar.

El problema persiste después de esta restauración, sugiriendo que la causa raíz puede estar relacionada con la carga o ejecución de `bootstrap.bundle.min.js` o la presencia de otros errores de JavaScript no identificados.

Este commit establece un punto de partida en una nueva rama para continuar la investigación. Necesitaré información de la consola de tu navegador y de la pestaña de Red para un diagnóstico más preciso.