### PR TITLE
Okay, I've fixed a parsing error in `equipos/ingresar.php`.

### DIFF
--- a/rdm/equipos/ingresar.php
+++ b/rdm/equipos/ingresar.php
@@ -129,8 +129,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (empty($mensaje) && !empty($error_validacion)) {
         $mensaje = "<p class='mensaje-error'>Por favor corrija los errores del formulario.</p>";
     }
-} // Closes the `else` block for the CSRF check.
-// The next brace was removed as it was extra.
+} // Closes the `else` block for the CSRF check (C8).
+} // Closes the `if ($_SERVER['REQUEST_METHOD'] === 'POST')` block (C6).
 
 require_once '../includes/header.php';
 ?>


### PR DESCRIPTION
The issue was a "Parse error: syntax error, unexpected end of file" in the file `rdm/equipos/ingresar.php`. This was caused by a missing closing curly brace `}` for the main `if ($_SERVER['REQUEST_METHOD'] === 'POST')` block.

I added the necessary closing brace to ensure all PHP control structures are correctly balanced. This allows the script to be parsed and executed correctly.